### PR TITLE
Bugfix for NCF not queuing components in assemblers

### DIFF
--- a/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
@@ -710,10 +710,13 @@ namespace NaniteConstructionSystem.Entities
         {
             MyAPIGateway.Parallel.Start(() =>
             {
-                IMySlimBlock block = null;
-                m_potentialInventoryBlocks.TryTake(out block);
-                if (block != null)
-                    TryAddToInventoryGroup(block);
+                while (!m_potentialInventoryBlocks.IsEmpty)
+                {
+                    IMySlimBlock block = null;
+                    m_potentialInventoryBlocks.TryTake(out block);
+                    if (block != null)
+                        TryAddToInventoryGroup(block);
+                }
             });
         }
 


### PR DESCRIPTION
Bugfix for NCF not queuing components in assemblers.

Shouldn't impact performance much, since it's a parallel task and there is not many blocks in the `m_potentialInventoryBlocks`.