### PR TITLE
Fix for #120 & Fixed max blocks scanned value

### DIFF
--- a/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
@@ -1129,7 +1129,7 @@ namespace NaniteConstructionSystem.Entities
 
                 foreach (var block in m_scanBlocksCache)
                 {
-                    if (counter++ > (maxBlocksToScan * 5))
+                    if (counter++ > (maxBlocksToScan))
                         break;
 
                     blocksToGo.Add(block);

--- a/Data/Scripts/NaniteConstructionSystem/Entities/Targets/NaniteConstructionTargets.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Entities/Targets/NaniteConstructionTargets.cs
@@ -202,7 +202,7 @@ namespace NaniteConstructionSystem.Entities.Targets
         {
             if (Sync.IsServer)
             {
-                if (m_constructionBlock.FactoryState != NaniteConstructionBlock.FactoryStates.Active || (m_constructionBlock.FactoryState != NaniteConstructionBlock.FactoryStates.MissingParts && TargetList.Count > 0 && PotentialTargetList.Count > 0))
+                if (!((m_constructionBlock.FactoryState == NaniteConstructionBlock.FactoryStates.Active || m_constructionBlock.FactoryState == NaniteConstructionBlock.FactoryStates.MissingParts) && (TargetList.Count > 0 || PotentialTargetList.Count > 0)))
                     return;
 
                 if (!m_targetBlocks.ContainsKey(target))

--- a/Data/Scripts/NaniteConstructionSystem/Settings/NaniteSettings.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Settings/NaniteSettings.cs
@@ -237,7 +237,7 @@ namespace NaniteConstructionSystem.Settings
             OreDetectorPowerPercentIncreasedPerScanningUpgrade = 1f;
             OreDetectorPowerPercentReducedPerEfficiencyUpgrade = 0.1f;
             AreaBeaconMaxDistanceFromNaniteFacility = 800f;
-            BlocksScannedPerSecond = 100;
+            BlocksScannedPerSecond = 500;
             MiningTargetsScannedPerSecond = 100;
             OreDetectorScanningSpeed = 10;
             Version = "2.0";


### PR DESCRIPTION
**Fix for #120:**
With the #122 patch I managed to create a situation where construction nanites weren't created. It is now fixed.

**Fixed max blocks scanned value:**
Max blocks scanned value was artificially multiplied by 5 in the code and was divided by 5 in config.xml
Made it so the config value is actually used.